### PR TITLE
Follow recent compatible layer manner

### DIFF
--- a/lib/fluent/plugin/in_diskusage.rb
+++ b/lib/fluent/plugin/in_diskusage.rb
@@ -1,3 +1,5 @@
+require 'fluent/input'
+
 class Fluent::DiskUsage < Fluent::Input
 	Fluent::Plugin.register_input('diskusage',self)
 

--- a/lib/fluent/plugin/in_diskusage.rb
+++ b/lib/fluent/plugin/in_diskusage.rb
@@ -50,6 +50,6 @@ class Fluent::DiskUsage < Fluent::Input
 	def shutdown
 		@watcher.terminate
 		@watcher.join
-
+		super
 	end
 end


### PR DESCRIPTION
With v0.14 compatible layer, Fluentd Input Plugin must require `fluent/input` and should call `super` in `#shutdown`.
