### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,9 @@
 require "bundler/gem_tasks"
+require 'rake/testtask'
+Rake::TestTask.new(:test) do |test|
+  test.libs << 'lib' << 'test'
+  test.pattern = 'test/**/test_*.rb'
+  test.verbose = true
+end
+
+task :default => :test

--- a/fluent-plugin-diskusage.gemspec
+++ b/fluent-plugin-diskusage.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "fluentd", [">= 0.10.30", "< 2"]
+  spec.add_dependency "fluentd", [">= 0.14.15", "< 2"]
   spec.add_dependency "sys-filesystem", "~> 1.1.4"
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/fluent-plugin-diskusage.gemspec
+++ b/fluent-plugin-diskusage.gemspec
@@ -20,4 +20,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "sys-filesystem", "~> 1.1.4"
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "test-unit", "~> 3.2"
+  spec.add_development_dependency "test-unit-rr", "~> 1.0"
 end

--- a/lib/fluent/plugin/in_diskusage.rb
+++ b/lib/fluent/plugin/in_diskusage.rb
@@ -1,13 +1,16 @@
-require 'fluent/input'
+require 'sys/filesystem'
+require 'fluent/plugin/input'
 
-class Fluent::DiskUsage < Fluent::Input
+class Fluent::Plugin::DiskUsage < Fluent::Plugin::Input
 	Fluent::Plugin.register_input('diskusage',self)
+
+	helpers :timer
 
 	# Define `router` method to support v0.10.57 or earlier
 	unless method_defined?(:router)
 		define_method("router") { Fluent::Engine }
 	end
-	
+
 	config_param :tag,		:string
 	config_param :mountpoint,	:string
 	config_param :label,		:string
@@ -15,19 +18,11 @@ class Fluent::DiskUsage < Fluent::Input
 
 	def configure(conf)
 		super
-		require 'sys/filesystem'
 	end
 
 	def start
 		super
-		@watcher = Thread.new(&method(:run))
-	end
-
-	def run
-		while true
-			output
-		sleep @refresh_interval
-		end
+		timer_execute(:in_diskusage_timer, @refresh_interval, &method(:output))
 	end
 
 	def output
@@ -37,19 +32,17 @@ class Fluent::DiskUsage < Fluent::Input
 		used_bytes = total_bytes - free_bytes
 		used_percent = 0
 		free_percent = 0
-		if total_bytes.nonzero?	
+		if total_bytes.nonzero?
 			used_percent = used_bytes / total_bytes.to_f
 			free_percent = free_bytes / total_bytes.to_f
 		end
 		record = {"label"=>@label,"total_bytes"=>total_bytes,"free_bytes"=>free_bytes,"used_bytes"=>used_bytes,"used_percent"=>used_percent,"free_percent"=>free_percent}
-	
+
 		time = Fluent::Engine.now
 		router.emit(tag,time,record)
 	end
 
 	def shutdown
-		@watcher.terminate
-		@watcher.join
 		super
 	end
 end

--- a/lib/fluent/plugin/in_diskusage.rb
+++ b/lib/fluent/plugin/in_diskusage.rb
@@ -1,3 +1,5 @@
+require 'fluent/input'
+
 class Fluent::DiskUsage < Fluent::Input
 	Fluent::Plugin.register_input('diskusage',self)
 

--- a/lib/fluent/plugin/in_diskusage.rb
+++ b/lib/fluent/plugin/in_diskusage.rb
@@ -50,6 +50,6 @@ class Fluent::DiskUsage < Fluent::Input
 	def shutdown
 		@watcher.terminate
 		@watcher.join
-
+		super
 	end
 end

--- a/lib/fluent/plugin/in_diskusage.rb
+++ b/lib/fluent/plugin/in_diskusage.rb
@@ -6,11 +6,6 @@ class Fluent::Plugin::DiskUsage < Fluent::Plugin::Input
 
 	helpers :timer
 
-	# Define `router` method to support v0.10.57 or earlier
-	unless method_defined?(:router)
-		define_method("router") { Fluent::Engine }
-	end
-
 	config_param :tag,		:string
 	config_param :mountpoint,	:string
 	config_param :label,		:string

--- a/test/plugin/test_in_diskusage.rb
+++ b/test/plugin/test_in_diskusage.rb
@@ -1,0 +1,63 @@
+require 'test/unit'
+require 'fluent/test'
+require 'fluent/test/helpers'
+require 'fluent/test/driver/input'
+require 'fluent/plugin/in_diskusage'
+
+class DiskUsageTest < Test::Unit::TestCase
+  include Fluent::Test::Helpers
+
+  def setup
+    Fluent::Test.setup
+  end
+
+  CONFIG = %[
+    tag         raw.diskusage
+    mountpoint  /
+    label       rootfs
+  ]
+
+  CONFIG_REFRESH_INTERVAL = %[
+    tag         raw.diskusage
+    mountpoint  /
+    label       rootfs
+    refresh_interval 5
+  ]
+
+  def create_driver(conf = CONFIG)
+    Fluent::Test::Driver::Input.new(Fluent::Plugin::DiskUsage).configure(conf)
+  end
+
+  class ConfigureTest < self
+    def test_default
+      d = create_driver
+      assert_equal 'raw.diskusage', d.instance.tag
+      assert_equal '/', d.instance.mountpoint
+      assert_equal 'rootfs', d.instance.label
+      assert_equal 120, d.instance.refresh_interval
+    end
+
+    def test_refresh_interval
+      d = create_driver(CONFIG_REFRESH_INTERVAL)
+      assert_equal 'raw.diskusage', d.instance.tag
+      assert_equal '/', d.instance.mountpoint
+      assert_equal 'rootfs', d.instance.label
+      assert_equal 5, d.instance.refresh_interval
+    end
+  end
+
+  def test_emit
+    d = create_driver(CONFIG + %[refresh_interval 1])
+    d.run(expect_emits: 1)
+    events = d.events
+    now = event_time
+    assert_equal "raw.diskusage", events[0][0]
+    assert_in_delta events[0][1].to_f, now.to_f, 0.5
+    assert_equal "rootfs", events[0][2]["label"]
+    assert_true events[0][2].has_key?("total_bytes")
+    assert_true events[0][2].has_key?("free_bytes")
+    assert_true events[0][2].has_key?("used_bytes")
+    assert_true events[0][2].has_key?("used_percent")
+    assert_true events[0][2].has_key?("free_percent")
+  end
+end


### PR DESCRIPTION
Please review and merge this PR after #1.

I've tried to use v0.14 Output plugin API.
This PR contains major update change.
Could you bump up minor version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks,